### PR TITLE
fix: updated section configuration for rule 0003

### DIFF
--- a/src/GlobalUsingsAnalyzer/GlobalUsingsAnalyzer.cs
+++ b/src/GlobalUsingsAnalyzer/GlobalUsingsAnalyzer.cs
@@ -52,7 +52,7 @@ namespace GlobalUsingsAnalyzer
             }
 
             Severity = DiagnosticSeverity.Warning;
-            if (config.TryGetValue("dotnet_diagnostic.GlobalUsingsAnalyzer0003.diagnostic_severity", out var severityString))
+            if (config.TryGetValue("dotnet_diagnostic.GlobalUsingsAnalyzer0003.severity", out var severityString))
             {
 
                 switch (severityString.ToLower())

--- a/src/ReadMe.md
+++ b/src/ReadMe.md
@@ -4,7 +4,15 @@ A C# analyzer that will suggest moving usings to a single project file. Defaults
 
 To change the name of the file (defaults to GlobalUsings.cs) add the following .editorconfig setting:
 
-**dotnet_diagnostic.GlobalUsingsAnalyzer.global_usings_filename = FILENAME.cs**
+**dotnet_diagnostic.GlobalUsingsAnalyzer0001.filename = FILENAME.cs**
+
+To disable the analyzer for a project/solution add the following .edtiorconfig setting:
+
+**dotnet_diagnostic.GlobalUsingsAnalyzer0002.enabled = false**
+
+To change the severity of the diagnostic per project/solution add the following .edtiorconfig setting:
+
+**dotnet_diagnostic.GlobalUsingsAnalyzer0003.severity = error** (can be info, warning, error or hidden)
 
 **Note: The diagnostics must be placed under the [*.cs] entry to work**
 


### PR DESCRIPTION
In documentation previously it was saying to use `dotnet_diagnostic.GlobalUsingsAnalyzer0003.severity = error` but it was not working due to: https://github.com/bjorndaniel/GlobalUsingsAnalyzer/blob/main/src/GlobalUsingsAnalyzer/GlobalUsingsAnalyzer.cs#L55

I updated it to match the diagnostic convention/format.